### PR TITLE
fix styled-components ssr

### DIFF
--- a/src/ssr.tsx
+++ b/src/ssr.tsx
@@ -22,7 +22,7 @@ if (process.env.SSR) {
       // styled-components typings are broken and explicitly force React.Element, so we override:
       return (sheet.getStyleElement() as unknown) as JSX.Element;
     };
-    sheet.seal();
+
     const SSRApp: FunctionComponent = (props) => (
       <Fragment>
         <StyleSheetManager sheet={sheet.instance}>


### PR DESCRIPTION
sheet.seal() is implicitly called by getStyleElement(), calling it there was sealing the sheet before it was populated.